### PR TITLE
Reduce GRADLE Test time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -555,6 +555,9 @@ coveralls {
 }
 
 allprojects {
+    tasks.withType(Test).configureEach {
+        forkEvery = 100
+    }
 	tasks.each { task ->
 		if (task instanceof Javadoc) {
 			//println task


### PR DESCRIPTION
[Process forking options](https://docs.gradle.org/current/userguide/performance.html#forking_options). Gradle will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork a new test VM after a certain number of tests have run by setting `forkEvery`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.